### PR TITLE
Replaced param in "List all subscribers" endpoint

### DIFF
--- a/examples/subscribers/get.js
+++ b/examples/subscribers/get.js
@@ -1,4 +1,4 @@
-// node examples/subscribers/get.js active 5 1
+// node examples/subscribers/get.js active 5
 
 "use strict";
 
@@ -17,7 +17,6 @@ if (process.argv.slice(2).length) {
     status: String(process.argv[2])
   };
   myArgs.limit = parseInt(process.argv[3]);
-  myArgs.page = parseInt(process.argv[4]);
 }
 
 mailerlite.subscribers.get(myArgs)

--- a/src/modules/subscribers/README.md
+++ b/src/modules/subscribers/README.md
@@ -10,8 +10,7 @@ const params = {
   filter: {
     status: "active" // possible statuses: active, unsubscribed, unconfirmed, bounced or junk.
   },
-  limit: 10,
-  page: 1
+  limit: 10
 };
 
 mailerlite.subscribers.get(params)

--- a/src/modules/subscribers/subscribers.test.ts
+++ b/src/modules/subscribers/subscribers.test.ts
@@ -29,8 +29,7 @@ describe("Subscribers", () => {
             filter: {
                 status: "active" // possible statuses: active, unsubscribed, unconfirmed, bounced or junk.
             },
-            limit: 5,
-            page: 1
+            limit: 5
         };
 
         try {

--- a/src/modules/subscribers/subscribers.types.ts
+++ b/src/modules/subscribers/subscribers.types.ts
@@ -20,7 +20,6 @@ export interface GetParams {
     /**
      * @default 1
      */
-    page?: number;
     cursor?: string;
 }
 


### PR DESCRIPTION
`page` parameter replaced with `cursor`

https://developers.mailerlite.com/docs/subscribers.html#list-all-subscribers