### PR TITLE
Fix GetGroupsParams interface

### DIFF
--- a/src/modules/groups/groups.types.ts
+++ b/src/modules/groups/groups.types.ts
@@ -15,7 +15,7 @@ export interface GetGroupsParams {
     limit?: number;
     page?:  number;
     filter?: {
-        name?: "sent" | "draft" | "ready";
+        name?: string;
     };
     sort: "name" | "total" | "open_rate" | "click_rate" | "created_at" | "-name" | "-total" | "-open_rate" | "-click_rate" | "-created_at";
 }


### PR DESCRIPTION
Issue: https://github.com/mailerlite/mailerlite-nodejs/issues/39

Fix GetGroupsParams interface. Name can be any string