### PR TITLE
Groups data is excluded by default

### DIFF
--- a/examples/subscribers/get.js
+++ b/examples/subscribers/get.js
@@ -1,4 +1,4 @@
-// node examples/subscribers/get.js active 5
+// node examples/subscribers/get.js active 5 groups
 
 "use strict";
 
@@ -17,6 +17,7 @@ if (process.argv.slice(2).length) {
     status: String(process.argv[2])
   };
   myArgs.limit = parseInt(process.argv[3]);
+  myArgs.include = String(process.argv[4]);
 }
 
 mailerlite.subscribers.get(myArgs)

--- a/src/modules/subscribers/subscribers.types.ts
+++ b/src/modules/subscribers/subscribers.types.ts
@@ -21,8 +21,9 @@ export interface GetSubscribersParams {
     /**
      * @default 1
      */
-    page?: number; // deprecated
-    cursor?: string;
+    page?:      number; // deprecated
+    cursor?:    string;
+    include?:   string;
 }
 
 export interface CreateOrUpdateSubscriberParams {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -90,7 +90,7 @@ export interface SubscriberObject {
         state:        string;
         z_i_p:        string;
     };
-    groups:           Array<GroupObject>;
+    groups?:          Array<GroupObject>; // In some endpoints groups are excluded by default. They get added when `include` param is used in request
     opted_in_at:      string;
     optin_ip:         string;
 }


### PR DESCRIPTION
**Issue**: https://github.com/mailerlite/mailerlite-nodejs/issues/35

**Description**:
In some endpoints groups are excluded by default. They get added when `include` param is used in request