### PR TITLE
Optional subscriber data in getSentCampaignSubscribers()

### DIFF
--- a/src/modules/stats/stats.module.ts
+++ b/src/modules/stats/stats.module.ts
@@ -56,7 +56,7 @@ export default class Statistics implements StatsInterface {
     }
 
     /**
-     * @description Get subscribers of sent campaign
+     * @description Get subscribers' activity of a sent campaign
      *
      * @see https://developers.mailerlite.com/docs/campaigns.html#get-subscribers-activity-of-a-sent-campaign
      *

--- a/src/modules/stats/stats.types.ts
+++ b/src/modules/stats/stats.types.ts
@@ -34,8 +34,9 @@ export interface CampaignSubscribersActivityParams {
     /**
      * @default "id"
      */
-    sort?:  "id" | "updated_at" | "clicks_count" | "opens_count";
-    page?:  number;
+    sort?:      "id" | "updated_at" | "clicks_count" | "opens_count";
+    page?:      number;
+    include?:   "subscriber"
 }
 
 export interface FormsSubscribersParams {
@@ -66,7 +67,7 @@ export interface ActivityObject {
     id:             string;
     opens_count:    number;
     clicks_count:   number;
-    subscriber:     SubscriberObject;
+    subscriber?:    SubscriberObject; // Subscriber data excluded by default
 }
 
 export interface StatsMeta extends Meta {

--- a/src/modules/subscribers/subscribers.types.ts
+++ b/src/modules/subscribers/subscribers.types.ts
@@ -23,7 +23,7 @@ export interface GetSubscribersParams {
      */
     page?:      number; // deprecated
     cursor?:    string;
-    include?:   string;
+    include?:   "groups";
 }
 
 export interface CreateOrUpdateSubscriberParams {


### PR DESCRIPTION
**Issue**: https://github.com/mailerlite/mailerlite-nodejs/issues/49

**Description**:
- Subscriber data is excluded by default. New request param to include subscriber data on request. In `getSentCampaignSubscribers()` endpoint
- Only groups can be included in `getSubscribers()` endpoint