### PR TITLE
Update Node.js version

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish


### PR DESCRIPTION
After updated [dev dependencies to their latest versions](https://github.com/mailerlite/mailerlite-nodejs/pull/84) publish workflow started failing. These newer versions and their dependencies started using modern JavaScript syntax (??= operator) that requires Node.js 15+ to run. 

Node.js 18.x because:
- It's the current LTS (Long Term Support) version
- It fully supports all modern JavaScript features including ??=