### PR TITLE
[SS] feature/no-ref/node-vulnerability-update

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
-          node-version: "24.x"
+          node-version: 22
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish


### PR DESCRIPTION

```diff
diff --git a/.github/workflows/publish.yaml b/.github/workflows/publish.yaml
index 6515d84ecc63a65e16230ef6afdce308e16a9d04..b205a0eaa6ac03c73073fc3c435e5b4d3c75e9fa 100644
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,7 +9,7 @@     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v4
         with:
-          node-version: "24.x"
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish

```