### PR TITLE
feat(npmjs): use trusted publisher approach instead npm token

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,13 +5,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
       - run: npm install
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission for OIDC authentication
- Remove `NPM_TOKEN` secret usage in favor of OIDC-based publishing

## Notes

- The `NPM_TOKEN` secret can be removed from the repository settings after this is merged and verified
- Trusted publisher must be configured on npmjs.com for this repository before merging