### PR TITLE
docs(batches): drop the leading slash from the batch path example (#86)

### DIFF
--- a/examples/batches/send.js
+++ b/examples/batches/send.js
@@ -31,7 +31,7 @@ const params = {
     },
     {
       method: "GET",
-      path:   "/api/forms/popup",
+      path:   "api/forms/popup",
       body:   {
         filter: {
           name: "nodejs"

--- a/src/modules/batches/README.md
+++ b/src/modules/batches/README.md
@@ -27,7 +27,7 @@ const params = {
     },
     {
       method: "GET",
-      path:   "/api/forms/popup",
+      path:   "api/forms/popup",
       body:   {
         filter: {
           name: "test popup"

--- a/src/modules/batches/batches.test.ts
+++ b/src/modules/batches/batches.test.ts
@@ -38,7 +38,7 @@ describe("Batches", () => {
                 },
                 {
                     method: "GET",
-                    path:   "/api/forms/popup",
+                    path:   "api/forms/popup",
                     body:   {
                         filter: {
                             name: "nodejs"


### PR DESCRIPTION
The batching docs state the relative path must start with `api/`, but one of the examples used `/api/forms/popup`.

The same inconsistent form had been copied into the example script and the test fixture, so this aligns all three with the `api/` form already used by the other examples in the same files:

- `src/modules/batches/README.md`
- `examples/batches/send.js`
- `src/modules/batches/batches.test.ts`

No behaviour change — documentation, example and fixture only.

Fixes #86

_AI-assisted, human-reviewed._
